### PR TITLE
Replace `keys` with `getOwnPropertyNames`

### DIFF
--- a/src/create-spy-from-class.ts
+++ b/src/create-spy-from-class.ts
@@ -182,7 +182,7 @@ function getAllMethodNames(obj: any) {
   let methods: string[] = [];
 
   do {
-    methods = methods.concat(Object.keys(obj));
+    methods = methods.concat(Object.getOwnPropertyNames(obj));
     obj = Object.getPrototypeOf(obj);
   } while (obj);
 


### PR DESCRIPTION
https://stackoverflow.com/questions/27267794/why-object-keysarray-prototype-returns-empty-array