### PR TITLE
fix: switch to getOwnPropertyNames for method name retreival

### DIFF
--- a/src/create-spy-from-class.ts
+++ b/src/create-spy-from-class.ts
@@ -131,13 +131,10 @@ function getAllMethodNames(obj: any): string[] {
   let methods: string[] = [];
 
   do {
-    methods = methods.concat(Object.keys(obj));
+    methods = methods.concat(Object.getOwnPropertyNames(obj));
     obj = Object.getPrototypeOf(obj);
   } while (obj);
 
-  const constructorIndex = methods.indexOf('constructor');
-  if (constructorIndex >= 0) {
-    methods.splice(constructorIndex, 1);
-  }
+  methods = methods.filter(m => m !== 'constructor');
   return methods;
 }

--- a/src/test-utils/fake-classes-to-test.ts
+++ b/src/test-utils/fake-classes-to-test.ts
@@ -3,6 +3,8 @@ import { Observable, of, Subject } from 'rxjs';
 export class FakeClass {
   public someProp: number = 1;
 
+  constructor() {}
+
   public syncMethod() {
     return '';
   }
@@ -30,6 +32,10 @@ export class FakeClass {
 
 // tslint:disable-next-line:max-classes-per-file
 export class FakeChildClass extends FakeClass {
+  constructor() {
+    super();
+  }
+
   public anotherObservableMethod(): Observable<any> {
     return of();
   }


### PR DESCRIPTION
refers to failed retreival of method names with code gernerated by typescrript > 3.x. Please see:
https://github.com/hirezio/jasmine-auto-spies/pull/12