### PR TITLE
feat(getters-setters) add getter and setter to current spied object

### DIFF
--- a/src/test-utils/fake-classes-to-test.ts
+++ b/src/test-utils/fake-classes-to-test.ts
@@ -26,3 +26,18 @@ export class FakeChildClass extends FakeClass {
     return of();
   }
 }
+// tslint:disable-next-line:max-classes-per-file
+export class FakeGetterSetterClass extends FakeClass {
+  // tslint:disable-next-line: variable-name
+  private _myProp = 'default value';
+  get myProp(): string {
+    return this._myProp;
+  }
+  set myProp(value: string) {
+    this._myProp = value;
+  }
+  get anotherGetter(): number {
+    return 1;
+  }
+  set mySetter(value: number) {}
+}


### PR DESCRIPTION
### Goal: Add the ability to spy on getter/setter properties
Ref: #3  

With this PR, when you call `let spiedObj = createSpyFunction` on an object/class, getters/setters are created on `spiedObj `
So calling spyOnProperty(spiedObj, 'yourProperty', 'get') will work now

+++++++++++++++++++++++++++++++++++++++++++++++
Note:
At some point, I realized that we can't reach accessors (getter/setter) properties and spy on them, only using spyOnProperty

Let's take this example:
`let ObjectClass = { get myProp() { return 'myProp value'; }`
on your test:

- create an autospy for this object:
`let fakeObjectClass = createSpyFromClass(ObjectClass );`
- Spy on the getter property:
`spyOnProperty(fakeGetterSetterClass, 'myProp', 'get').and.returnValue(fakeValue);`
- Assert:
`expect(fakeGetterSetterClass.myProp).toBe(fakeValue);`